### PR TITLE
Fix major glitches in Mattie's world.

### DIFF
--- a/lmh-matties-world/images/LMH_iceberg_worldmap.strf
+++ b/lmh-matties-world/images/LMH_iceberg_worldmap.strf
@@ -160,9 +160,9 @@
 (tiles
 	(width 4)(height 4)
 	(images 
-		(region "worldmap/shared/roads.png" 96 128 32 32)
+		(region "worldmap/shared/invisible_paths.png" 0 0 128 128)
 	)
-	(editor-images "worldmap/shared/invisible_paths-editor.png")
+	(editor-images "worldmap/shared/invisible_paths-editor.png" 0 0 128 128)
 	(ids
 		2030 2031 2032 2033
 		2034 2035 2036 2037
@@ -285,7 +285,7 @@
 (tile
   (id 1)
   (images
-    (region "worldmap/shared/roads.png" 64 64 32 32)
+    (region "worldmap/shared/invisible_paths.png" 64 32 32 32)
   )
   (editor-images
     (region "worldmap/shared/invisible_paths-editor.png" 64 32 32 32)

--- a/lmh-matties-world/levels/mattie_world/doom_islands/Airship.stl
+++ b/lmh-matties-world/levels/mattie_world/doom_islands/Airship.stl
@@ -5980,7 +5980,7 @@
       (width 960)
       (height 64)
       (x 0)
-      (y 3872)
+      (y 3584)
     )
     (spawnpoint
       (name "main")

--- a/lmh-matties-world/levels/mattie_world/doom_islands/default.nut
+++ b/lmh-matties-world/levels/mattie_world/doom_islands/default.nut
@@ -46,7 +46,7 @@ if(!("coin_level_active" in state)){
 
 progress <- state.island_bonus;
 reward <- state.island_reveal;
-levelvars <- state.worlds["levels/mattie_world/doom_islands/worldmap.stwm"].levels;
+levelvars <- state.worlds["/levels/mattie_world/doom_islands/worldmap.stwm"].levels;
 in_cave <- state.underground;
 
 //FOLLOWING USED TO PREVENT ERROR DUE TO MAP SHORTENING

--- a/lmh-matties-world/levels/mattie_world/mattie_iceberg/S_Airship.stl
+++ b/lmh-matties-world/levels/mattie_world/mattie_iceberg/S_Airship.stl
@@ -2833,7 +2833,7 @@
         )
         (node
           (x 980)
-          (y 288)
+          (y 2880)
           (time 0.2)
         )
       )
@@ -5927,7 +5927,7 @@
       (width 960)
       (height 64)
       (x 0)
-      (y 3872)
+      (y 3584)
     )
     (spawnpoint
       (name "main")

--- a/lmh-matties-world/levels/mattie_world/mattie_iceberg/default.nut
+++ b/lmh-matties-world/levels/mattie_world/mattie_iceberg/default.nut
@@ -266,7 +266,7 @@ function find(egg){
 
 function show_map_rewards(){
   if(reward["secrets"]){
-    wait(1);
+//    wait(1);
     shop.fade(1,3);
     reward["secrets"] <- false;
     save_progress();
@@ -276,7 +276,7 @@ function show_map_rewards(){
   }
 
   if(reward["mineshaft"]){
-    wait(1);
+//    wait(1);
     SSH_MS.fade(0,0);
     SSB_MS.fade(1,3);
     reward["mineshaft"] <- false;
@@ -288,7 +288,7 @@ function show_map_rewards(){
     SSH_MS.fade(0,0);
 
   if(reward["airship"]){
-    wait(1);
+//    wait(1);
     SSH_AS.fade(0,0);
     SSB_AS.fade(1,3);
     reward["airship"] <- false;
@@ -300,7 +300,7 @@ function show_map_rewards(){
     SSH_AS.fade(0,0);
 
   if(reward["castle"]){
-    wait(1);
+//    wait(1);
     SSH_TC.fade(0,0);
     SSB_TC.fade(1,3);
     reward["castle"] <- false;


### PR DESCRIPTION
I expected [addon repo](https://github.com/SuperTux/addons/tree/master/repository) to be a snapshot of [addon src](https://github.com/SuperTux/addons-src) or something, but I can't handle those messy blobs with git, so leave the changes here.

- There are four "Super Secret Bonus Levels" in the worldmap, 16dfa0322f1aabf75ff42d5bc5d7a1d17e3bcaa4 is required. But I think it would be better to fix the behavior of wait() instead of removing it.
- I roughly increased the height of the scripttrigger so that Tux could finish the level when it fell, and changed the direction of the wood's movement to make sure the crystal was falling downwards.
- The following issues is about broken tiles etc.
    - SuperTux/addons#25
    - SuperTux/addons-src#20